### PR TITLE
Export request with retry

### DIFF
--- a/arccnet/data_generation/data_manager.py
+++ b/arccnet/data_generation/data_manager.py
@@ -194,8 +194,8 @@ class DataManager:
         # !TODO itereate over children of `BaseMagnetogram`
         hmi_keys = self.hmi.fetch_metadata(self.start_date, self.end_date, batch_frequency=12, to_csv=self.save_to_csv)
         mdi_keys = self.mdi.fetch_metadata(self.start_date, self.end_date, batch_frequency=12, to_csv=self.save_to_csv)
-        sharp_k = self.sharps.fetch_metadata(self.start_date, self.end_date, batch_frequency=3, to_csv=self.save_to_csv)
-        smarp_k = self.smarps.fetch_metadata(self.start_date, self.end_date, batch_frequency=3, to_csv=self.save_to_csv)
+        sharp_k = self.sharps.fetch_metadata(self.start_date, self.end_date, batch_frequency=4, to_csv=self.save_to_csv)
+        smarp_k = self.smarps.fetch_metadata(self.start_date, self.end_date, batch_frequency=4, to_csv=self.save_to_csv)
 
         # logging
         for name, dataframe in {


### PR DESCRIPTION
A few exceptions have been captured in `DataManager._data_export_request`.

The initial exception is always `http.client.RemoteDisconnected` with a message stating, "Remote end closed connection without response." This is captured in the try/except block in the new method, `_data_export_request_with_retry`, and another request is made after a time delay.

Depending on how quickly that next query is made, the original query can still be pending on JSOC, raising `drms.exceptions.DrmsExportError`. The output of this is shown below (taken from the CI, RE #65)

```python
self = <ExportRequest: id=None, status=7>, notfound_ok = True

    def _raise_on_error(self, notfound_ok=True):
        if self._status in self._status_codes_ok_or_pending:
            if self._status != self._status_code_notfound or notfound_ok:
                return  # request has not failed (yet)
        msg = self._d.get("error")
        if msg is None:
            msg = "DRMS export request failed."
        msg += f" [status={int(self._status)}]"
>       raise DrmsExportError(msg)
E       drms.exceptions.DrmsExportError: User pjwright@stanford.edu has 1 pending export requests (JSOC_20230901_952); please wait until at least one request has completed before submitting a new one. [status=7]
```

Here are two log snippets for reference:

```
2023-09-01 23:34:45,974 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2019.05.01_00:00:00-2019.09.01_00:00:00@1d] returned 91 results
2023-09-01 23:34:45,975 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:35:25,923 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2019.09.01_00:00:00-2020.01.01_00:00:00@1d] returned 42 results
2023-09-01 23:35:25,923 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:36:07,719 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2020.01.01_00:00:00-2020.05.01_00:00:00@1d] returned 62 results
2023-09-01 23:36:07,719 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:36:53,069 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2020.05.01_00:00:00-2020.09.01_00:00:00@1d] returned 129 results
2023-09-01 23:36:53,070 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:37:44,505 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2020.09.01_00:00:00-2021.01.01_00:00:00@1d] returned 279 results
2023-09-01 23:37:44,506 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:38:56,777 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2021.01.01_00:00:00-2021.05.01_00:00:00@1d] returned 261 results
2023-09-01 23:38:56,777 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:40:10,295 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2021.05.01_00:00:00-2021.09.01_00:00:00@1d] returned 511 results
2023-09-01 23:40:10,296 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:41:43,152 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2021.09.01_00:00:00-2022.01.01_00:00:00@1d] returned 690 results
2023-09-01 23:41:43,154 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:43:44,246 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2022.01.01_00:00:00-2022.05.01_00:00:00@1d] returned 1032 results
2023-09-01 23:43:44,247 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:44:44,471 - base_magnetogram.py:239 - WARNING -    ... Exception: 'Remote end closed connection without response'. Retrying in 5 seconds: retry 1 of 3.
2023-09-01 23:44:49,476 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:44:59,463 - base_magnetogram.py:254 - WARNING -    ... Exception: 'Cant save new export-request hash. [status=4]'. Retrying in 5 seconds: retry 2 of 3.
2023-09-01 23:44:59,464 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:45:00,477 - base_magnetogram.py:249 - INFO -       ... waiting 60 seconds for pending export requests to complete.
2023-09-01 23:46:00,478 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:46:29,430 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2022.05.01_00:00:00-2022.09.01_00:00:00@1d] returned 1221 results
2023-09-01 23:46:29,431 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:47:29,666 - base_magnetogram.py:239 - WARNING -    ... Exception: 'Remote end closed connection without response'. Retrying in 5 seconds: retry 1 of 3.
2023-09-01 23:47:34,672 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:47:55,708 - base_magnetogram.py:254 - WARNING -    ... Exception: 'Cant save new export-request hash. [status=4]'. Retrying in 5 seconds: retry 2 of 3.
2023-09-01 23:47:55,709 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:47:56,656 - base_magnetogram.py:249 - INFO -       ... waiting 60 seconds for pending export requests to complete.
2023-09-01 23:48:56,659 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:49:25,647 - base_magnetogram.py:533 - INFO -       HMISHARPs Query: hmi.sharp_720s[][2022.09.01_00:00:00-2022.12.31_00:00:00@1d] returned 1147 results
2023-09-01 23:49:25,648 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:50:25,954 - base_magnetogram.py:239 - WARNING -    ... Exception: 'Remote end closed connection without response'. Retrying in 5 seconds: retry 1 of 3.
2023-09-01 23:50:30,959 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:50:54,186 - base_magnetogram.py:254 - WARNING -    ... Exception: 'Cant save new export-request hash. [status=4]'. Retrying in 5 seconds: retry 2 of 3.
2023-09-01 23:50:54,186 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:50:55,305 - base_magnetogram.py:249 - INFO -       ... waiting 60 seconds for pending export requests to complete.
2023-09-01 23:51:55,311 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:51:57,355 - base_magnetogram.py:249 - INFO -       ... waiting 60 seconds for pending export requests to complete.
2023-09-01 23:52:57,358 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-01 23:53:06,468 - base_magnetogram.py:324 - INFO - The metadata for HMISHARPs has been saved to /Users/pjwright/Documents/work/ARCCnet/data/01_raw/mag/sharps/raw.csv
2023-09-01 23:53:09,714 - base_magnetogram.py:472 - INFO - (27783, 495)
```
```
2023-09-01 23:53:09,754 - base_magnetogram.py:437 - INFO - >> Fetching metadata for MDISMARPs. The requests are batched into batches of 4 months
2023-09-01 23:53:12,889 - base_magnetogram.py:530 - WARNING -    MDISMARPs Query: mdi.smarp_96m[][1995.01.01_00:00:00-1995.05.01_00:00:00@1d] returned 0 results
2023-09-01 23:53:13,821 - base_magnetogram.py:530 - WARNING -    MDISMARPs Query: mdi.smarp_96m[][1995.05.01_00:00:00-1995.09.01_00:00:00@1d] returned 0 results

...

2023-09-02 00:00:40,677 - base_magnetogram.py:533 - INFO -       MDISMARPs Query: mdi.smarp_96m[][1999.05.01_00:00:00-1999.09.01_00:00:00@1d] returned 1947 results
2023-09-02 00:00:40,679 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:01:40,913 - base_magnetogram.py:239 - WARNING -    ... Exception: 'Remote end closed connection without response'. Retrying in 5 seconds: retry 1 of 3.
2023-09-02 00:01:45,917 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:02:54,893 - base_magnetogram.py:533 - INFO -       MDISMARPs Query: mdi.smarp_96m[][1999.09.01_00:00:00-2000.01.01_00:00:00@1d] returned 1779 results
2023-09-02 00:02:54,895 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:03:55,154 - base_magnetogram.py:239 - WARNING -    ... Exception: 'Remote end closed connection without response'. Retrying in 5 seconds: retry 1 of 3.
2023-09-02 00:04:00,158 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:04:06,851 - base_magnetogram.py:254 - WARNING -    ... Exception: 'Cant save new export-request hash. [status=4]'. Retrying in 5 seconds: retry 2 of 3.
2023-09-02 00:04:06,852 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:04:07,937 - base_magnetogram.py:249 - INFO -       ... waiting 60 seconds for pending export requests to complete.
2023-09-02 00:05:07,947 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:05:29,550 - base_magnetogram.py:533 - INFO -       MDISMARPs Query: mdi.smarp_96m[][2000.01.01_00:00:00-2000.05.01_00:00:00@1d] returned 2127 results
2023-09-02 00:05:29,552 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:06:29,792 - base_magnetogram.py:239 - WARNING -    ... Exception: 'Remote end closed connection without response'. Retrying in 5 seconds: retry 1 of 3.
2023-09-02 00:06:34,797 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:07:57,298 - base_magnetogram.py:533 - INFO -       MDISMARPs Query: mdi.smarp_96m[][2000.05.01_00:00:00-2000.09.01_00:00:00@1d] returned 2451 results
2023-09-02 00:07:57,298 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:08:57,531 - base_magnetogram.py:239 - WARNING -    ... Exception: 'Remote end closed connection without response'. Retrying in 5 seconds: retry 1 of 3.
2023-09-02 00:09:02,537 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:10:37,319 - base_magnetogram.py:533 - INFO -       MDISMARPs Query: mdi.smarp_96m[][2000.09.01_00:00:00-2001.01.01_00:00:00@1d] returned 2421 results
2023-09-02 00:10:37,319 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:11:37,554 - base_magnetogram.py:239 - WARNING -    ... Exception: 'Remote end closed connection without response'. Retrying in 5 seconds: retry 1 of 3.
2023-09-02 00:11:42,559 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:13:09,289 - base_magnetogram.py:533 - INFO -       MDISMARPs Query: mdi.smarp_96m[][2001.01.01_00:00:00-2001.05.01_00:00:00@1d] returned 2231 results
2023-09-02 00:13:09,290 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:14:09,537 - base_magnetogram.py:239 - WARNING -    ... Exception: 'Remote end closed connection without response'. Retrying in 5 seconds: retry 1 of 3.
2023-09-02 00:14:14,538 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:15:31,355 - base_magnetogram.py:533 - INFO -       MDISMARPs Query: mdi.smarp_96m[][2001.05.01_00:00:00-2001.09.01_00:00:00@1d] returned 2189 results
2023-09-02 00:15:31,356 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:16:31,579 - base_magnetogram.py:239 - WARNING -    ... Exception: 'Remote end closed connection without response'. Retrying in 5 seconds: retry 1 of 3.
2023-09-02 00:16:36,582 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
2023-09-02 00:17:43,767 - base_magnetogram.py:533 - INFO -       MDISMARPs Query: mdi.smarp_96m[][2001.09.01_00:00:00-2002.01.01_00:00:00@1d] returned 2453 results
2023-09-02 00:17:43,768 - base_magnetogram.py:291 - INFO -       ... requesting bitmap urls from JSOC
```