### PR TITLE
Fix docs build in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ description = Invoke sphinx-build to build the HTML docs
 extras = docs
 commands =
     pip freeze --all --no-input
-    sphinx-build -j auto --color -W --keep-going -b html -d _build/.doctrees . _build/html {posargs}
+    sphinx-build -j 1 --color -W --keep-going -b html -d _build/.doctrees . _build/html {posargs}
     python -c 'import pathlib; print("Documentation available under file://\{0\}".format(pathlib.Path(r"{toxinidir}") / "docs" / "_build" / "index.html"))'
 
 [testenv:codestyle]


### PR DESCRIPTION
Closes: #100


We probably want to specifically suppress the exact warnings rather than forcing a single thread for doc building?