### PR TITLE
Rearrange magnetogram processing

### DIFF
--- a/arccnet/data_generation/mag_processing.py
+++ b/arccnet/data_generation/mag_processing.py
@@ -391,9 +391,9 @@ class RegionExtractor:
             # workaround for issues seen in processing
             data = image_map.data
             on_disk_nans = np.isnan(data)
-            if on_disk_nans.sum() > 0:
-                indices = np.where(on_disk_nans)
-                data[indices] = 0.0
+            # if on_disk_nans.sum() > 0:
+            #     indices = np.where(on_disk_nans)
+            #     data[indices] = 0.0
 
             regions = []
 


### PR DESCRIPTION
Depending on the order of rotation and zeroing of off-disk NaNs (rotation first leads to rounding issues that leave a ring of nans around the edge of the disk).

This PR changes the order of operations, and removes the zeroing of on-disk nans.

![image](https://github.com/ARCAFF/ARCCnet/assets/8172222/cb4bbb08-d609-42d9-b61f-264e172d5f5e)
![image](https://github.com/ARCAFF/ARCCnet/assets/8172222/acc7686f-ad0e-42d5-b7cc-85bce823a771)

Closes: #104 