### PR TITLE
Refactoring for IA regions not being Filtered

### DIFF
--- a/arccnet/data_generation/mag_processing.py
+++ b/arccnet/data_generation/mag_processing.py
@@ -476,11 +476,11 @@ class RegionExtractor:
             regions = []
 
             # add active regions to regions list
-            I_IA_regions = self._validregion_extraction(rows, image_map, cutout_size, path=data_path)
+            valid_regions = self._validregion_extraction(rows, image_map, cutout_size, path=data_path)
             rows_filtered_labels, rows_filtered_unlabeled, filtered_regions = self._filteredregion_extraction(
                 rows_filtered, image_map, cutout_size, path=data_path
             )
-            regions.extend(I_IA_regions)
+            regions.extend(valid_regions)
 
             # ... update the table
             assert len(rows) == len(regions)


### PR DESCRIPTION
Now handle regions based on their `row['id']`, which for 2010-06-22, goes from:

```
      target_time       number region_type filtered_hmi                                filter_reason_hmi                               
----------------------- ------ ----------- ------------ -------------------------------------------------------------------------------
2010-06-22T00:00:00.000      0          QS        False                                                                                
2010-06-22T00:00:00.000      1          QS        False                                                                                
2010-06-22T00:00:00.000      2          QS        False                                                                                
2010-06-22T00:00:00.000      3          QS        False                                                                                
2010-06-22T00:00:00.000      4          QS        False                                                                                
2010-06-22T00:00:00.000      5          QS        False                                                                                
2010-06-22T00:00:00.000      6          QS        False                                                                                
2010-06-22T00:00:00.000      7          QS        False                                                                                
2010-06-22T00:00:00.000      8          QS        False                                                                                
2010-06-22T00:00:00.000      9          QS        False                                                                                
2010-06-22T00:00:00.000  11076          II         True not_ar,invalid_magnetic_class,invalid_mcintosh_class,bad_lat_rate,bad_lon_rate,
2010-06-22T00:00:00.000  11082          AR        False                                                                                
2010-06-22T00:00:00.000  11083          IA         True                           not_ar,invalid_magnetic_class,invalid_mcintosh_class,
```

to:

```
      target_time       number region_type filtered_hmi filter_reason_hmi
----------------------- ------ ----------- ------------ -----------------
2010-06-22T00:00:00.000      0          QS        False                  
2010-06-22T00:00:00.000      1          QS        False                  
2010-06-22T00:00:00.000      2          QS        False                  
2010-06-22T00:00:00.000      3          QS        False                  
2010-06-22T00:00:00.000      4          QS        False                  
2010-06-22T00:00:00.000      5          QS        False                  
2010-06-22T00:00:00.000      6          QS        False                  
2010-06-22T00:00:00.000      7          QS        False                  
2010-06-22T00:00:00.000      8          QS        False                  
2010-06-22T00:00:00.000      9          QS        False                  
2010-06-22T00:00:00.000  11076          II         True           not_ar,
2010-06-22T00:00:00.000  11082          AR        False                  
2010-06-22T00:00:00.000  11083          IA        False                  
```


and we now get timesteps where there are only `IA` and `QS`, e.g.:

```
      target_time       number region_type filtered_hmi filter_reason_hmi
----------------------- ------ ----------- ------------ -----------------
2010-04-12T00:00:00.000      0          QS           --                --
2010-04-12T00:00:00.000      1          QS           --                --
2010-04-12T00:00:00.000      2          QS           --                --
2010-04-12T00:00:00.000      3          QS           --                --
2010-04-12T00:00:00.000      4          QS           --                --
2010-04-12T00:00:00.000      5          QS           --                --
2010-04-12T00:00:00.000      6          QS           --                --
2010-04-12T00:00:00.000      7          QS           --                --
2010-04-12T00:00:00.000      8          QS           --                --
2010-04-12T00:00:00.000      9          QS           --                --
2010-04-12T00:00:00.000  11060          IA           --                --
```
![20100412_000026_MDI](https://github.com/ARCAFF/ARCCnet/assets/8172222/af06b5eb-b083-4a31-9a61-982a90f600cf)


and for 

```
      target_time       number region_type filtered_hmi     filter_reason_hmi     
----------------------- ------ ----------- ------------ --------------------------
2010-06-04T00:00:00.000      0          QS        False                           
2010-06-04T00:00:00.000      1          QS        False                           
2010-06-04T00:00:00.000      2          QS        False                           
2010-06-04T00:00:00.000      3          QS        False                           
2010-06-04T00:00:00.000      4          QS        False                           
2010-06-04T00:00:00.000      5          QS        False                           
2010-06-04T00:00:00.000      6          QS        False                           
2010-06-04T00:00:00.000      7          QS        False                           
2010-06-04T00:00:00.000      8          QS        False                           
2010-06-04T00:00:00.000      9          QS        False                           
2010-06-04T00:00:00.000  11073          IA        False                           
2010-06-04T00:00:00.000  11075          IA        False                           
2010-06-04T00:00:00.000  11076          FB         True bad_lat_rate,bad_lon_rate,
```

We see the `AR` filtered (now `FB`):

![20100603_235825_HMI_SIDE1](https://github.com/ARCAFF/ARCCnet/assets/8172222/9fb50234-0483-400a-bdf6-ac4ad201ebd8)